### PR TITLE
TOGGLEを修正

### DIFF
--- a/pasxx.rb
+++ b/pasxx.rb
@@ -72,11 +72,10 @@ def swap
 end
 
 def toggle
-  puts "SWAP"
   puts "DUP"
   roll_imm(3, 2)
   puts "DUP"
-  roll_imm(3, 1)
+  roll_imm(4, 1)
   puts <<"EOS"
 PUSH 3
 ADD


### PR DESCRIPTION
TOGGLEを行うと一番上のスタックが一番下に移り、他のスタックがひとつずつ上がる。(そういった仕様だと理解して修正しました)

動作のあれを以下に記述します。[ ... ] x が一つのスタックと思ってください。

```
|[ ... ] m ... [ ... ] n S
|[ ... ] m ... [ ... ] n S S # dup
|[ ... ] m ... [ ... ] S S n # roll 3 2
|[ ... ] m ... [ ... ] S S n n # dup
|[ ... ] m ... [ ... ] n S S n # roll 4 1
|[ ... ] m ... [ ... ] n S S n+3 # add 3
|[ ... ] m ... [ ... ] n S S n+3 1 # push 1
|[ ... ] m ... S [ ... ] n S # roll
|[ ... ] m ... S [ ... ] n S+1 # add 1
|[ ... ] m ... S [ ... ] S+1 n # swap
|[ ... ] m ... S [ ... ] S+1 n  n # dup
|[ ... ] m ... S [ ... ] n S+1 n # roll 3 1
|[ ... ] m ... S [ ... ] n S+1 n+1 # add 1
|[ ... ] n [ ... ] m ... S # roll
```
